### PR TITLE
Clean up compiler warnings

### DIFF
--- a/Backend/Controllers/ScheduleController.cs
+++ b/Backend/Controllers/ScheduleController.cs
@@ -17,9 +17,9 @@ public class ScheduleController : ControllerBase
         _hub = hub;
     }
 
-    private DateTimeOffset GetThisWeek() => TimeZoneInfo.ConvertTime((DateTimeOffset)DateTimeOffset.UtcNow.UtcDateTime, TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles"));
+    private static DateTimeOffset GetThisWeek() => TimeZoneInfo.ConvertTime((DateTimeOffset)DateTimeOffset.UtcNow.UtcDateTime, TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles"));
 
-    private Tuple<DateTimeOffset, DateTimeOffset> GetWeek(bool nextWeek = false)
+    private static Tuple<DateTimeOffset, DateTimeOffset> GetWeek(bool nextWeek = false)
     {
         var first = GetThisWeek();
         first = first.DayOfWeek switch

--- a/Backend/Discord/Market.cs
+++ b/Backend/Discord/Market.cs
@@ -24,7 +24,7 @@ public class Market : ISlashCommandProcessor
     }
 
     [SlashCommand("search", "Searches the market for an item")]
-    public async Task Search([SlashCommand("item", "The item to search for")] string item, [SlashCommand("server", "The server to search on")] string server, [SlashCommand("error-bars", "Shows error bars in the graph")] bool? errorBars)
+    public async Task Search([SlashCommand("item", "The item to search for")] string item, [SlashCommand("server", "The server to search on")] string server)
     {
         var worlds = await _universalisClient.GetWorlds();
         var datacenters = await _universalisClient.GetDatacenters();
@@ -36,7 +36,7 @@ public class Market : ISlashCommandProcessor
             names.Add(datacenter.Region);
             names.AddRange(datacenter.Worlds.Select(x => worlds.First(t => t.Id == x).Name));
         }
-        _logger.LogTrace($"Trying with server: {server} and item: {item}");
+        _logger.LogTrace("Trying with server: {server} and item: {item}", server, item);
         if (!names.Any(t => string.Equals(t, server, StringComparison.InvariantCultureIgnoreCase)))
         {
             await _arg.ModifyOriginalResponseAsync(msg => msg.Content = $"Could not find server {server}");
@@ -49,7 +49,7 @@ public class Market : ISlashCommandProcessor
             await _arg.ModifyOriginalResponseAsync(msg => msg.Content = $"Could not find item {item}");
             return;
         }
-        _logger.LogTrace($"Found server and item count {itemDatas.Count}");
+        _logger.LogTrace("Found server and item count {count}", itemDatas.Count);
         var builder = new EmbedBuilder();
         var sb = new StringBuilder();
         if (itemDatas.Count > 1)
@@ -70,13 +70,13 @@ public class Market : ISlashCommandProcessor
             });
             return;
         }
-        _logger.LogTrace($"Found item {itemDatas[0].Name}");
+        _logger.LogTrace("Found item {name}", itemDatas[0].Name);
         var itemData = itemDatas.First();
         var listing = await _universalisClient.GetListing(server, itemData.Id);
         var history = await _universalisClient.GetHistory(server, itemData.Id);
         _logger.LogTrace($"Got listing and history");
         var priceHistory = history.GetPriceHistory();
-        var hPlt = history.GetPlot(_gameClient.MarketItems, errorBars ?? false).GetImage(1100, 400);
+        var hPlt = history.GetPlot(_gameClient.MarketItems).GetImage(1100, 400);
         var mPlt = listing.GetPlot().GetImage(1100, 200);
         var plt = new SKBitmap(1100, 600);
         using (var canvas = new SKCanvas(plt))
@@ -184,16 +184,16 @@ public class Market : ISlashCommandProcessor
             return;
         }
 
-        _logger.LogTrace($"Trying with server {server}");
+        _logger.LogTrace("Trying with server {server}", server);
         if (!worlds.Any(t => string.Equals(t.Name, server, StringComparison.InvariantCultureIgnoreCase)))
         {
             await _arg.ModifyOriginalResponseAsync(msg => msg.Content = $"No world exists of name: {server}");
             return;
         }
         var world = worlds.First(t => string.Equals(t.Name, server, StringComparison.InvariantCultureIgnoreCase));
-        _logger.LogTrace($"Found server {world.Name}");
+        _logger.LogTrace("Found server {name}", world.Name);
         var tax = await _universalisClient.GetTaxRates(world.Id);
-        _logger.LogTrace($"Got tax data: {tax}");
+        _logger.LogTrace("Got tax data: {tax}", tax);
         var embedBuilder = new EmbedBuilder();
         embedBuilder.WithTitle($"Market tax rates for: {world.Name}");
         embedBuilder.AddField("Limsa Lominsa", $"{tax.LimsaLominsa}%", true);

--- a/Backend/Discord/Voice.cs
+++ b/Backend/Discord/Voice.cs
@@ -6,15 +6,13 @@ namespace PDPWebsite.Discord;
 [SlashCommand("voice", "Temp Voice related commands"), AllowedChannel(1065927404238942259)]
 public partial class Voice : ISlashCommandProcessor
 {
-    private ILogger<Market> _logger;
-    private SocketSlashCommand _arg;
-    private DiscordConnection _discord;
-    private RedisClient _redisClient;
+    private readonly SocketSlashCommand _arg;
+    private readonly DiscordConnection _discord;
+    private readonly RedisClient _redisClient;
 
-    public Voice(SocketSlashCommand arg, ILogger<Market> logger, DiscordConnection discord, RedisClient redis)
+    public Voice(SocketSlashCommand arg, DiscordConnection discord, RedisClient redis)
     {
         _arg = arg;
-        _logger = logger;
         _discord = discord;
         _redisClient = redis;
     }
@@ -23,16 +21,12 @@ public partial class Voice : ISlashCommandProcessor
 [SlashCommand("voice-debug", "Temp Voice Debug related commands", GuildPermission.ManageChannels), AllowedChannel(1065927404238942259)]
 public partial class VoiceAdmin : ISlashCommandProcessor
 {
-    private ILogger<Market> _logger;
-    private SocketSlashCommand _arg;
-    private DiscordConnection _discord;
-    private RedisClient _redisClient;
+    private readonly SocketSlashCommand _arg;
+    private readonly DiscordConnection _discord;
 
-    public VoiceAdmin(SocketSlashCommand arg, ILogger<Market> logger, DiscordConnection discord, RedisClient redis)
+    public VoiceAdmin(SocketSlashCommand arg, DiscordConnection discord)
     {
         _arg = arg;
-        _logger = logger;
         _discord = discord;
-        _redisClient = redis;
     }
 }

--- a/Backend/Discord/Voice/Modify.cs
+++ b/Backend/Discord/Voice/Modify.cs
@@ -11,12 +11,11 @@ public partial class Voice
     {
         var user = (SocketGuildUser)_arg.User;
         var channel = user.VoiceChannel;
-        if (!_discord.TempChannels.ContainsKey(channel.Id))
+        if (!_discord.TempChannels.TryGetValue(channel.Id, out ulong ownerId))
         {
             await _arg.ModifyOriginalResponseAsync(msg => msg.Content = "Channel is not a temp channel");
             return;
         }
-        var ownerId = _discord.TempChannels[channel.Id];
         if (channel.ConnectedUsers.Any(x => x.Id == ownerId))
         {
             await _arg.ModifyOriginalResponseAsync(msg => msg.Content = "Owner is still in the channel");
@@ -31,12 +30,11 @@ public partial class Voice
     {
         var user = (SocketGuildUser)_arg.User;
         var channel = user.VoiceChannel;
-        if (!_discord.TempChannels.ContainsKey(channel.Id))
+        if (!_discord.TempChannels.TryGetValue(channel.Id, out ulong ownerId))
         {
             await _arg.ModifyOriginalResponseAsync(msg => msg.Content = "Channel is not a temp channel");
             return;
         }
-        var ownerId = _discord.TempChannels[channel.Id];
         if (ownerId != user.Id)
         {
             await _arg.ModifyOriginalResponseAsync(msg => msg.Content = "You are not the owner of this channel");
@@ -73,12 +71,11 @@ public partial class Voice
     {
         var user = (SocketGuildUser)_arg.User;
         var channel = user.VoiceChannel;
-        if (!_discord.TempChannels.ContainsKey(channel.Id))
+        if (!_discord.TempChannels.TryGetValue(channel.Id, out ulong ownerId))
         {
             await _arg.ModifyOriginalResponseAsync(msg => msg.Content = "Channel is not a temp channel");
             return;
         }
-        var ownerId = _discord.TempChannels[channel.Id];
         if (ownerId != user.Id)
         {
             await _arg.ModifyOriginalResponseAsync(msg => msg.Content = "You are not the owner of this channel");
@@ -103,12 +100,11 @@ public partial class Voice
     {
         var user = (SocketGuildUser)_arg.User;
         var channel = user.VoiceChannel;
-        if (!_discord.TempChannels.ContainsKey(channel.Id))
+        if (!_discord.TempChannels.TryGetValue(channel.Id, out ulong ownerId))
         {
             await _arg.ModifyOriginalResponseAsync(msg => msg.Content = "Channel is not a temp channel");
             return;
         }
-        var ownerId = _discord.TempChannels[channel.Id];
         if (ownerId != user.Id)
         {
             await _arg.ModifyOriginalResponseAsync(msg => msg.Content = "You are not the owner of this channel");
@@ -126,12 +122,11 @@ public partial class Voice
     {
         var user = (SocketGuildUser)_arg.User;
         var channel = user.VoiceChannel;
-        if (!_discord.TempChannels.ContainsKey(channel.Id))
+        if (!_discord.TempChannels.TryGetValue(channel.Id, out ulong ownerId))
         {
             await _arg.ModifyOriginalResponseAsync(msg => msg.Content = "Channel is not a temp channel");
             return;
         }
-        var ownerId = _discord.TempChannels[channel.Id];
         if (ownerId != user.Id)
         {
             await _arg.ModifyOriginalResponseAsync(msg => msg.Content = "You are not the owner of this channel");

--- a/Backend/DiscordLogger.cs
+++ b/Backend/DiscordLogger.cs
@@ -7,9 +7,9 @@ namespace PDPWebsite;
 [Target("Discord")]
 public class DiscordLogger : TargetWithLayout
 {
-    private DiscordConnection? Connection => DiscordConnection.Instance;
-    private Queue<LogEventInfo> _logQueue = new();
-    private Queue<Embed> _embeds = new();
+    private static DiscordConnection? Connection => DiscordConnection.Instance;
+    private readonly Queue<LogEventInfo> _logQueue = new();
+    private readonly Queue<Embed> _embeds = new();
 
     public DiscordLogger()
     {

--- a/Backend/FFXIV/Item.cs
+++ b/Backend/FFXIV/Item.cs
@@ -12,7 +12,7 @@ public class Item
     public string Name;
     public ushort Icon;
 
-    private GameClient _gameData;
+    private readonly GameClient _gameData;
 
     public Item(GameClient gameClient)
     {

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -99,28 +99,30 @@ discord.Dispose();
 
 LogManager.Shutdown();
 
-public class UlongStringConverter : JsonConverter<ulong>
-{
-    public override ulong Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+namespace PDPWebsite {
+    public class UlongStringConverter : JsonConverter<ulong>
     {
-        return ulong.Parse(reader.GetString()!);
+        public override ulong Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return ulong.Parse(reader.GetString()!);
+        }
+
+        public override void Write(Utf8JsonWriter writer, ulong value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString());
+        }
     }
 
-    public override void Write(Utf8JsonWriter writer, ulong value, JsonSerializerOptions options)
+    public class TimeSpanStringConverter : JsonConverter<TimeSpan>
     {
-        writer.WriteStringValue(value.ToString());
-    }
-}
+        public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return TimeSpan.Parse(reader.GetString()!, new DateTimeFormatInfo { ShortTimePattern = "hh':'mm" });
+        }
 
-public class TimeSpanStringConverter : JsonConverter<TimeSpan>
-{
-    public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-    {
-        return TimeSpan.Parse(reader.GetString()!, new DateTimeFormatInfo { ShortTimePattern = "hh':'mm" });
-    }
-
-    public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options)
-    {
-        writer.WriteStringValue(value.ToString("hh':'mm"));
+        public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString("hh':'mm"));
+        }
     }
 }

--- a/Backend/Services/DiscordConnection.MessageInteractions.cs
+++ b/Backend/Services/DiscordConnection.MessageInteractions.cs
@@ -7,10 +7,9 @@ public partial class DiscordConnection
 {
     private async Task DiscordClientOnModalSubmitted(SocketModal arg)
     {
-        _logger.LogTrace($"DiscordClientOnModalSubmitted: {arg}");
+        _logger.LogTrace("DiscordClientOnModalSubmitted: {arg}", arg);
         var user = (SocketGuildUser)arg.User;
         var channel = user.VoiceChannel;
-        ulong ownerId;
         switch (arg.Data.CustomId)
         {
             case "rename":
@@ -19,12 +18,11 @@ public partial class DiscordConnection
                     await arg.RespondAsync("Must be in a voice channel", ephemeral: true);
                     return;
                 }
-                if (!TempChannels.ContainsKey(channel!.Id))
+                if (!TempChannels.TryGetValue(channel!.Id, out ulong ownerId))
                 {
                     await arg.RespondAsync("Channel is not a temp channel", ephemeral: true);
                     return;
                 }
-                ownerId = TempChannels[channel.Id];
                 if (ownerId != user.Id)
                 {
                     await arg.RespondAsync("You are not the owner of this channel", ephemeral: true);
@@ -45,7 +43,7 @@ public partial class DiscordConnection
 
     private async Task MessageInteractionExecuted(SocketMessageComponent arg)
     {
-        _logger.LogTrace($"MessageInteractionExecuted: {arg.Data.CustomId}");
+        _logger.LogTrace("MessageInteractionExecuted: {id}", arg.Data.CustomId);
         var user = (SocketGuildUser)arg.User;
         var channel = user.VoiceChannel;
         ulong ownerId;
@@ -57,12 +55,11 @@ public partial class DiscordConnection
                     await arg.RespondAsync("Must be in a voice channel", ephemeral: true);
                     return;
                 }
-                if (!TempChannels.ContainsKey(channel!.Id))
+                if (!TempChannels.TryGetValue(channel!.Id, out ownerId))
                 {
                     await arg.RespondAsync("Channel is not a temp channel", ephemeral: true);
                     return;
                 }
-                ownerId = TempChannels[channel.Id];
                 if (ownerId != user.Id)
                 {
                     await arg.RespondAsync("You are not the owner of this channel", ephemeral: true);
@@ -82,12 +79,11 @@ public partial class DiscordConnection
                     await arg.RespondAsync("Must be in a voice channel", ephemeral: true);
                     return;
                 }
-                if (!TempChannels.ContainsKey(channel!.Id))
+                if (!TempChannels.TryGetValue(channel!.Id, out ownerId))
                 {
                     await arg.RespondAsync("Channel is not a temp channel", ephemeral: true);
                     return;
                 }
-                ownerId = TempChannels[channel.Id];
                 if (channel.ConnectedUsers.Any(x => x.Id == ownerId))
                 {
                     await arg.RespondAsync("Owner is still in the channel", ephemeral: true);
@@ -102,12 +98,11 @@ public partial class DiscordConnection
                     await arg.RespondAsync("Must be in a voice channel", ephemeral: true);
                     return;
                 }
-                if (!TempChannels.ContainsKey(channel!.Id))
+                if (!TempChannels.TryGetValue(channel!.Id, out ownerId))
                 {
                     await arg.RespondAsync("Channel is not a temp channel", ephemeral: true);
                     return;
                 }
-                ownerId = TempChannels[channel.Id];
                 if (ownerId != user.Id)
                 {
                     await arg.RespondAsync("You are not the owner of this channel", ephemeral: true);
@@ -126,12 +121,11 @@ public partial class DiscordConnection
                     await arg.RespondAsync("Must be in a voice channel", ephemeral: true);
                     return;
                 }
-                if (!TempChannels.ContainsKey(channel!.Id))
+                if (!TempChannels.TryGetValue(channel!.Id, out ownerId))
                 {
                     await arg.RespondAsync("Channel is not a temp channel", ephemeral: true);
                     return;
                 }
-                ownerId = TempChannels[channel.Id];
                 if (ownerId != user.Id)
                 {
                     await arg.RespondAsync("You are not the owner of this channel", ephemeral: true);

--- a/Backend/Services/DiscordConnection.SlashCommands.cs
+++ b/Backend/Services/DiscordConnection.SlashCommands.cs
@@ -87,7 +87,7 @@ public partial class DiscordConnection
                         var values = Enum.GetValues(paramType);
                         if (values.Length > 25)
                         {
-                            _logger.LogError($"Enum {paramType.Name} has more than 25 values, this is not supported by discord.");
+                            _logger.LogError("Enum {name} has more than 25 values, this is not supported by discord.", paramType.Name);
                             goto enumEscape;
                         }
                         foreach (var value in values)
@@ -182,7 +182,7 @@ public partial class DiscordConnection
                             _ when typeSafe == typeof(SocketUser) => paramOption.Value,
                             _ when typeSafe == typeof(SocketChannel) => paramOption.Value,
                             _ when typeSafe == typeof(Attachment) => paramOption.Value,
-                            _ => throw new ArgumentOutOfRangeException(nameof(typeSafe), typeSafe, $"Could not match type with {typeSafe.Name}")
+                            _ => throw new ArgumentOutOfRangeException(typeSafe.Name, typeSafe, $"Could not match type with {typeSafe.Name}")
                         })!);
                     }
                 }
@@ -197,7 +197,7 @@ public partial class DiscordConnection
         }
         catch (Exception e)
         {
-            _logger.LogError(e, $"SlashCommandExecuted failed while executing: `/{command} {subCommand}` with args: {string.Join(", ", args.Select(t => t.ToString()))}");
+            _logger.LogError(e, "SlashCommandExecuted failed while executing: `/{command} {subCommand}` with args: {args}", command, subCommand, string.Join(", ", args.Select(t => t.ToString())));
         }
     }
 }

--- a/Backend/Services/DiscordConnection.Voice.cs
+++ b/Backend/Services/DiscordConnection.Voice.cs
@@ -12,10 +12,10 @@ public partial class DiscordConnection
         {
             if (before.VoiceChannel == after.VoiceChannel)
                 return;
-            _logger.LogTrace($"UserVoiceStateUpdated: {user}, {before}, {after}");
+            _logger.LogTrace("UserVoiceStateUpdated: {user}, {before}, {after}", user, before, after);
             if (before.VoiceChannel != null && (after.VoiceChannel == null || before.VoiceChannel.Id != after.VoiceChannel.Id))
             {
-                _logger.LogTrace($"User: {user} disconnected from voice channel {before}");
+                _logger.LogTrace("User: {user} disconnected from voice channel {before}", user, before);
                 if (before.VoiceChannel.ConnectedUsers.Count == 0 && TempChannels.ContainsKey(before.VoiceChannel.Id))
                 {
                     _logger.LogTrace($"This was the last user that left a temp channel");
@@ -25,7 +25,7 @@ public partial class DiscordConnection
                 else if (before.VoiceChannel.ConnectedUsers.Count > 0 && TempChannels.ContainsKey(before.VoiceChannel.Id))
                 {
                     _logger.LogTrace($"This was not the last user that left a temp channel");
-                    _logger.LogTrace($"Users discovered: {string.Join(", ", before.VoiceChannel.ConnectedUsers.Select(t => t.ToString()))}");
+                    _logger.LogTrace("Users discovered: {users}", string.Join(", ", before.VoiceChannel.ConnectedUsers.Select(t => t.ToString())));
                 }
                 else if (!TempChannels.ContainsKey(before.VoiceChannel.Id))
                 {
@@ -34,7 +34,7 @@ public partial class DiscordConnection
             }
             if (after.VoiceChannel?.Id == _tempVoiceChannel.Id)
             {
-                _logger.LogTrace($"User: {user} connected to temp voice setup.");
+                _logger.LogTrace("User: {user} connected to temp voice setup.", user);
                 var names = _redisClient.GetObj<Dictionary<ulong, string>>($"voice_names");
                 if (names == null || !names.TryGetValue(user.Id, out var name))
                     name = user.Username;

--- a/Backend/Services/DiscordConnection.cs
+++ b/Backend/Services/DiscordConnection.cs
@@ -88,7 +88,7 @@ public partial class DiscordConnection : IDisposable
             LogSeverity.Verbose => MSLogLevel.Trace,
             LogSeverity.Debug => MSLogLevel.Debug,
             _ => MSLogLevel.Information
-        }, arg.Exception, arg.Message);
+        }, arg.Exception, "{message}", arg.Message);
         return Task.CompletedTask;
     }
 
@@ -140,6 +140,7 @@ public partial class DiscordConnection : IDisposable
     public void Dispose()
     {
         DisposeAsync().GetAwaiter().GetResult();
+        GC.SuppressFinalize(this);
     }
 
     public bool ShouldLog(NLogLevel logEventLevel)

--- a/Backend/Services/GameClient.cs
+++ b/Backend/Services/GameClient.cs
@@ -11,7 +11,7 @@ public class GameClient : IDisposable
     private readonly GameData _gameData;
     private readonly UniversalisClient _client;
 
-    private List<Item> _marketItems = new();
+    private readonly List<Item> _marketItems = new();
     public IReadOnlyList<Item> MarketItems => _marketItems;
 
     public GameClient(UniversalisClient client)
@@ -58,5 +58,6 @@ public class GameClient : IDisposable
 
     public void Dispose()
     {
+        GC.SuppressFinalize(this);
     }
 }

--- a/Backend/Services/RedisClient.cs
+++ b/Backend/Services/RedisClient.cs
@@ -6,14 +6,11 @@ namespace PDPWebsite.Services;
 
 public class RedisClient
 {
-    private ILogger<RedisClient> _logger;
-
-    public RedisClient(ILogger<RedisClient> logger)
+    public RedisClient()
     {
-        _logger = logger;
     }
 
-    private static TimeSpan expireConstant = new(7, 0, 0, 0);
+    private static readonly TimeSpan expireConstant = new(7, 0, 0, 0);
 
     public ConnectionMultiplexer Connection { get; set; } = ConnectionMultiplexer.Connect("localhost");
 

--- a/Backend/Universalis/Datacenter.cs
+++ b/Backend/Universalis/Datacenter.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿#pragma warning disable CA1507
+
+using Newtonsoft.Json;
 
 namespace PDPWebsite.Universalis
 {

--- a/Backend/Universalis/History.cs
+++ b/Backend/Universalis/History.cs
@@ -87,13 +87,13 @@ namespace PDPWebsite.Universalis
         [JsonProperty("worldName")]
         public string WorldName { get; init; }
 
-        public Plot GetPlot(IEnumerable<Item> items, bool errorBars = false)
+        public Plot GetPlot(IEnumerable<Item> items)
         {
             var plt = new Plot();
             var salesTmp = Sales.Select(t => new SanitizedSale(t)).GroupBy(t => t.Date);
 
             var list = salesTmp.Select(f => new ProcessedSale(f)).OrderBy(t => t.Date).ToList();
-            list.GetSalesPlot(plt, errorBars);
+            list.GetSalesPlot(plt);
             plt.Legend();
             plt.Title($"Average Price of {items.First(t => t.Id == ItemId)!.Name}");
             plt.YLabel("Price");
@@ -246,7 +246,7 @@ namespace PDPWebsite.Universalis
             return values.ToDictionary(key, value, EqualityComparer<TK>.Default).OrderBy(t => t.Key).ToDictionary(t => t.Key, t => t.Value);
         }
 
-        public static void GetSalesPlot(this IEnumerable<ProcessedSale> sales, Plot plt, bool errorBars)
+        public static void GetSalesPlot(this IEnumerable<ProcessedSale> sales, Plot plt)
         {
             var avgSales = sales.ToDictionaryOrdered(sale => sale.Date.ToOADate(), sale => sale.AveragePrice);
             var avgSalesNq = sales.Where(sale => sale.AveragePriceNq.HasValue).ToDictionaryOrdered(sale => sale.Date.ToOADate(), sale => sale.AveragePriceNq!.Value);


### PR DESCRIPTION
Pretty straightforward stuff. Just missing some `readonly` modifiers, a couple unused args and a lot of log format strings that weren't static.

I'll make a followup PR after I run resharper's formatter on the codebase, just as soon as I find a way to successfully run it on Linux.